### PR TITLE
Expose TLS config

### DIFF
--- a/rest/server.go
+++ b/rest/server.go
@@ -100,6 +100,7 @@ type Server interface {
 	Uptime() time.Duration
 	Service(name string) Service
 	HTTPConfig() HTTPServerConfig
+	TLSConfig() *tls.Config
 
 	// IsReady indicates that all subservices are ready to serve
 	IsReady() bool
@@ -293,6 +294,11 @@ func (server *HTTPServer) Name() string {
 // HTTPConfig returns HTTPServerConfig
 func (server *HTTPServer) HTTPConfig() HTTPServerConfig {
 	return server.httpConfig
+}
+
+// TLSConfig returns TLSConfig
+func (server *HTTPServer) TLSConfig() *tls.Config {
+	return server.tlsConfig
 }
 
 // AddNode returns created node and a list of peers after adding the node to the cluster.

--- a/rest/server_test.go
+++ b/rest/server_test.go
@@ -196,6 +196,22 @@ func Test_NewServer(t *testing.T) {
 	require.NotNil(t, e)
 }
 
+func Test_TLSConfig(t *testing.T) {
+	cfg := &serverConfig{
+		BindAddr: ":8081",
+	}
+
+	audit := auditor.NewInMemory()
+
+	tlsConfig := &tls.Config{}
+	server, err := rest.New("v1.0.123", "", cfg, tlsConfig, audit, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	assert.NotNil(t, server.TLSConfig)
+	assert.Equal(t, tlsConfig, server.TLSConfig())
+}
+
 func Test_ResolveTCPAddr(t *testing.T) {
 	cfg := &serverConfig{
 		ServiceName: "invalid",


### PR DESCRIPTION
It is useful to have TLS config exposed. E.g. in one of our projects for debugging reasons this info will be helpful.