### PR TITLE
Add a method to enable attaching a RequestContext to a golang context.

### DIFF
--- a/xhttp/identity/ctx.go
+++ b/xhttp/identity/ctx.go
@@ -75,6 +75,11 @@ func FromContext(ctx context.Context) *RequestContext {
 	return ret
 }
 
+//AddToContext returns a new golang context that adds `rq` as the dolly request context.
+func AddToContext(ctx context.Context, rq *RequestContext) context.Context {
+	return context.WithValue(ctx, keyContext, rq)
+}
+
 // ForRequest returns the full context ascocicated with this http request.
 func ForRequest(r *http.Request) *RequestContext {
 	v := r.Context().Value(keyContext)

--- a/xhttp/identity/ctx.go
+++ b/xhttp/identity/ctx.go
@@ -37,6 +37,12 @@ type RequestContext struct {
 	clientIP      string
 }
 
+func NewRequestContext(id Identity) *RequestContext {
+	return &RequestContext{
+		identity:      id,
+	}
+}
+
 // Context represents user contextual information about a request being processed by the server,
 // it includes identity, CorrelationID [for cross system request correlation].
 type Context interface {

--- a/xhttp/identity/ctx_test.go
+++ b/xhttp/identity/ctx_test.go
@@ -77,9 +77,7 @@ func Test_ClientIP(t *testing.T) {
 func Test_AddToContext(t *testing.T) {
 	ctx := AddToContext(
 		context.Background(),
-		&RequestContext{
-			identity: NewIdentity("r", "n", "u"),
-		},
+		NewRequestContext(NewIdentity("r", "n", "u")),
 	)
 
 	rqCtx := FromContext(ctx)

--- a/xhttp/identity/ctx_test.go
+++ b/xhttp/identity/ctx_test.go
@@ -1,6 +1,7 @@
 package identity
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -71,6 +72,23 @@ func Test_ClientIP(t *testing.T) {
 
 	handler.ServeHTTP(rw, r)
 	assert.NotEqual(t, "", rw.Header().Get(header.XHostname))
+}
+
+func Test_AddToContext(t *testing.T) {
+	ctx := AddToContext(
+		context.Background(),
+		&RequestContext{
+			identity: NewIdentity("r", "n", "u"),
+		},
+	)
+
+	rqCtx := FromContext(ctx)
+	require.NotNil(t, rqCtx)
+
+	identity := rqCtx.Identity()
+	require.Equal(t, "n", identity.Name())
+	require.Equal(t, "r", identity.Role())
+	require.Equal(t, "u", identity.UserID())
 }
 
 func Test_FromContext(t *testing.T) {


### PR DESCRIPTION
This is useful for use in unit tests.