### PR TITLE
Do not initialize logrotator for ctl

### DIFF
--- a/rest/server_test.go
+++ b/rest/server_test.go
@@ -336,7 +336,7 @@ func (tm *testMuxer) NewMux() http.Handler {
 }
 
 func muxer(handler http.Handler) *testMuxer {
-	return &testMuxer {handler: handler}
+	return &testMuxer{handler: handler}
 }
 
 type cluster struct {

--- a/xhttp/identity/ctx.go
+++ b/xhttp/identity/ctx.go
@@ -40,7 +40,7 @@ type RequestContext struct {
 // NewRequestContext creates a request context with a specific identity.
 func NewRequestContext(id Identity) *RequestContext {
 	return &RequestContext{
-		identity:      id,
+		identity: id,
 	}
 }
 


### PR DESCRIPTION
Recently couple of our customers who use stampy-tool to verify signatures started facing the below issue. After some investigation we found out that it is related to the issue reported in https://github.com/natefinch/lumberjack/issues/56. It basically boils down to some go routine leaking in underlying log rotate related packages. 

However more importantly we found that log rotator in dolly does not really need to be initialized for ctl and is not used anywhere. So to fix the issue we are simply removing the log rotator variable from ctl.

```
Error in executing Stampy-tool: github.com/go-phorce/dolly/vendor/gopkg.in/alecthomas/kingpin%2ev2.(*Application).Parse(0xc00027a690, 0xc0000321f0, 0x5, 0x5, 0x8, 0xdd60e0, 0x1927e60, 0x7f839e0a8d98)
Error in executing Stampy-tool: /tmp/gopath/stampy-tool/src/github.com/go-phorce/dolly/vendor/gopkg.in/alecthomas/kingpin.v2/app.go:222 +0x203
Error in executing Stampy-tool: github.com/go-phorce/dolly/ctl.(*proxyapp).Parse(0xc0001e41b0, 0xc0000321f0, 0x5, 0x5, 0x7f839e0a8d98, 0x0, 0x8cbb2791, 0x4af20e6e8200a071)
Error in executing Stampy-tool: /tmp/gopath/stampy-tool/src/github.com/go-phorce/dolly/ctl/proxy.go:46 +0x4c
Error in executing Stampy-tool: github.com/go-phorce/dolly/ctl.(*Ctl).Parse(0xc00021a6c0, 0xc0000321e0, 0x6, 0x6, 0x0, 0x0)
Error in executing Stampy-tool: /tmp/gopath/stampy-tool/src/github.com/go-phorce/dolly/ctl/ctl.go:290 +0x9f
Error in executing Stampy-tool: main.realMain(0xc0000321e0, 0x6, 0x6, 0x1031080, 0xc000010018, 0xc0000fa058)
Error in executing Stampy-tool: /tmp/gopath/stampy-tool/src/git.soma.salesforce.com/stampy-tool/main/main.go:322 +0xcbaa
Error in executing Stampy-tool: main.main()
Error in executing Stampy-tool: /tmp/gopath/stampy-tool/src/git.soma.salesforce.com/stampy-tool/main/main.go:29 +0x5d
Error in executing Stampy-tool:
Error in executing Stampy-tool: goroutine 5 [syscall]:
Error in executing Stampy-tool: os/signal.signal_recv(0x0)
Error in executing Stampy-tool: /usr/local/go/src/runtime/sigqueue.go:139 +0x9c
Error in executing Stampy-tool: os/signal.loop()
Error in executing Stampy-tool: /usr/local/go/src/os/signal/signal_unix.go:23 +0x22
Error in executing Stampy-tool: created by os/signal.init.0
Error in executing Stampy-tool: /usr/local/go/src/os/signal/signal_unix.go:29 +0x41
Error in executing Stampy-tool:
Error in executing Stampy-tool: goroutine 34 [chan receive]:
Error in executing Stampy-tool: github.com/go-phorce/dolly/vendor/gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun(0xc0001dd3e0)
Error in executing Stampy-tool: 	/tmp/gopath/stampy-tool/src/github.com/go-phorce/dolly/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:379 +0x58
Error in executing Stampy-tool: created by github.com/go-phorce/dolly/vendor/gopkg.in/natefinch/lumberjack%2ev2.(*Logger).mill.func1
Error in executing Stampy-tool: 	/tmp/gopath/stampy-tool/src/github.com/go-phorce/dolly/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:390 +0x79
Error in executing Stampy-tool: 
Error in executing Stampy-tool: rax    0xca
Error in executing Stampy-tool: rbx    0x1927e60
Error in executing Stampy-tool: rcx    0xffffffffffffffff
Error in executing Stampy-tool: rdx    0x0
Error in executing Stampy-tool: rdi    0x1927fa8
Error in executing Stampy-tool: rsi    0x80
Error in executing Stampy-tool: rbp    0x7ffd196e5b80
Error in executing Stampy-tool: rsp    0x7ffd196e5b38
Error in executing Stampy-tool: r8     0x0
Error in executing Stampy-tool: r9     0x0
Error in executing Stampy-tool: r10    0x0
Error in executing Stampy-tool: r11    0x286
Error in executing Stampy-tool: r12    0x44
Error in executing Stampy-tool: r13    0x18e30e0
Error in executing Stampy-tool: r14    0x0
Error in executing Stampy-tool: r15    0x0
Error in executing Stampy-tool: rip    0x45f841
Error in executing Stampy-tool: rflags 0x286
Error in executing Stampy-tool: cs     0x33
Error in executing Stampy-tool: fs     0x0
Error in executing Stampy-tool: gs     0x0
```